### PR TITLE
OpenFL next support

### DIFF
--- a/dependencies/android/facebook-sdk/project.properties
+++ b/dependencies/android/facebook-sdk/project.properties
@@ -13,7 +13,7 @@ android.library.reference.1=../extension-api
 android.library.reference.2=../android-support-v4
 
 # Project target.
-target=android-10
+target=android-19
 
 java.target=1.7
 java.source=1.7

--- a/dependencies/android/facebook-sdk/src/org/haxe/extension/facebook/FacebookExtension.java
+++ b/dependencies/android/facebook-sdk/src/org/haxe/extension/facebook/FacebookExtension.java
@@ -220,10 +220,17 @@ public class FacebookExtension extends Extension {
 			}
 		};
 
-		AccessToken token = AccessToken.getCurrentAccessToken();
-		if (token!=null) {
-			callbacks.call1("_onTokenChange", token.getToken());
-		}
+		mainActivity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+            	AccessToken token = AccessToken.getCurrentAccessToken();
+				if (token!=null) {
+					callbacks.call1("_onTokenChange", token.getToken());
+				} else {
+					callbacks.call1("_onTokenChange", "");
+				}
+			}
+		});
 
 	}
 

--- a/dependencies/android/facebook-sdk/src/org/haxe/extension/facebook/FacebookExtension.java
+++ b/dependencies/android/facebook-sdk/src/org/haxe/extension/facebook/FacebookExtension.java
@@ -393,7 +393,14 @@ public class FacebookExtension extends Extension {
 						if (error==null) {
 							callbacks.call3("onGraphCallback", "ok", response.getRawResponse(), id);
 						} else {
-							callbacks.call3("onGraphCallback", "error", error.getRequestResult().toString(), id);
+							String errorMessage;
+
+							if (error.getRequestResult() == null) {
+								errorMessage = "{}";
+							} else {
+								errorMessage = error.getRequestResult().toString();	
+							}
+							callbacks.call3("onGraphCallback", "error", errorMessage, id);
 						}
 					}
 				}
@@ -401,7 +408,7 @@ public class FacebookExtension extends Extension {
 			}
 		);
 		mainActivity.runOnUiThread(new Runnable() {
-			@Override
+			@Override	
 			public void run() {
 				req.executeAsync();
 			}

--- a/dependencies/android/facebook-sdk/src/org/haxe/extension/facebook/FacebookExtension.java
+++ b/dependencies/android/facebook-sdk/src/org/haxe/extension/facebook/FacebookExtension.java
@@ -444,7 +444,9 @@ public class FacebookExtension extends Extension {
 	}
 
 	@Override public void onDestroy() {
-		accessTokenTracker.stopTracking();
+		if (accessTokenTracker != null) {
+			accessTokenTracker.stopTracking();
+		}
 	}
 
 }

--- a/extension/facebook/Facebook.hx
+++ b/extension/facebook/Facebook.hx
@@ -32,17 +32,30 @@ class Facebook extends TaskExecutor {
 	static var initted = false;
 	public var accessToken : String;
 
+	private var initCallback:Bool->Void;
+
 	public function new() {
 		accessToken = "";
+		super();
+	}
+
+	public function init(initCallback:Bool->Void) {
 		if (!initted) {
 			#if (android || ios)
-			FacebookCFFI.init(function(token) {
-				this.accessToken = token;
-			});
+			this.initCallback = initCallback;
+			FacebookCFFI.init(this.setAuthToken);
 			#end
+		}
+	}
+
+	public function setAuthToken(token) {
+		if (token != "") {
 			initted = true;
 		}
-		super();
+		this.accessToken = token;
+		if (this.initCallback != null) {
+			this.initCallback(true);
+		}
 	}
 
 	public function login(

--- a/extension/facebook/android/FacebookCallbacks.hx
+++ b/extension/facebook/android/FacebookCallbacks.hx
@@ -91,6 +91,9 @@ class FacebookCallbacks extends TaskExecutor {
 
 	function onGraphCallback(status : String, data : String, id : Int) {
 		var gCallback = graphCallbacks.get(id);
+		if (gCallback == null) {
+			return;
+		}
 		if (status!="error") {
 			if (gCallback.onComplete!=null) {
 				addTask(new CallStrTask(gCallback.onComplete, data));

--- a/extension/facebook/android/FacebookExtension.hx
+++ b/extension/facebook/android/FacebookExtension.hx
@@ -12,7 +12,7 @@ class FacebookExtension {
 		}
 		var str = "";
 		for (s in arr) {
-			str += s + ";";
+			str += s + ",";
 		}
 		return str;
 	}


### PR DESCRIPTION
## Overview

This PR will bring _android_ (iOS still untested) support for non legacy openFL apps.
## Technical changes

1) The token is marshaled back from JNI to Haxe on the UI thread.
2) Init supports a callback for better event base initialization
3) Multiple app requests can now be sent.
## Notes

This is not an ideal solution to the threading issue, but has no impact on our project.  Please make a TODO to fix the threading issues.
